### PR TITLE
Look behind and ahead 1 line when scanning for org-mode links

### DIFF
--- a/README.org
+++ b/README.org
@@ -115,6 +115,12 @@ These special keywords can be used when searching:
 :TOC:      ignore-children
 :END:
 
+*** 0.2.1
+
+**** Fixes
+
+-  Handle null or blank URLs returned by Pocket.  (Fixes [[https://github.com/alphapapa/pocket-reader.el/issues/19][#19]], [[https://github.com/alphapapa/pocket-reader.el/issues/20][#20]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
+
 *** 0.2
 
 **** Additions

--- a/README.org
+++ b/README.org
@@ -120,6 +120,7 @@ These special keywords can be used when searching:
 **** Fixes
 
 -  Handle null or blank URLs returned by Pocket.  (Fixes [[https://github.com/alphapapa/pocket-reader.el/issues/19][#19]], [[https://github.com/alphapapa/pocket-reader.el/issues/20][#20]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
+-  Handle links in Org buffers that span lines.  (Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 
 *** 0.2
 

--- a/pocket-reader.el
+++ b/pocket-reader.el
@@ -654,8 +654,9 @@ one.  ITEM should be a hash-table with the appropriate keys, one
 of which is chosen as configured by
 `pocket-reader-url-priorities'."
   (let ((prioritized-url (cl-loop for key in pocket-reader-url-priorities
-                                  when (ht-get item key) ; Gets the URL
-                                  return it)))
+                                  for url = (ht-get item key) ; Gets the URL
+                                  when (s-present? url)
+                                  return url)))
     (if first
         prioritized-url
       (if-let ((domain (pocket-reader--url-domain prioritized-url))

--- a/pocket-reader.el
+++ b/pocket-reader.el
@@ -1230,7 +1230,7 @@ eww, elfeed, and Org."
 (defun pocket-reader-org-add-link ()
   "Add link at point to Pocket in Org buffers."
   (interactive)
-  (when-let ((url (when (org-in-regexp org-bracket-link-regexp)
+  (when-let ((url (when (org-in-regexp org-bracket-link-regexp 1)
                     (org-link-unescape (match-string-no-properties 1)))))
     (when (pocket-lib-add-urls url)
       (message "Added: %s" url))))


### PR DESCRIPTION
Links can often span a line break, especially when the paragraph
containing them has been folded.  Allow the detection of these links
by scanning a bit around the line at point.

I chose to only look around by 1 line because it seems pretty uncommon to have a link long enough to span 3 lines, although it might make also sense to make this customizable.