### PR TITLE
Fix #20

### DIFF
--- a/README.org
+++ b/README.org
@@ -115,6 +115,12 @@ These special keywords can be used when searching:
 :TOC:      ignore-children
 :END:
 
+*** 0.2.1
+
+**** Fixes
+
+-  Handle null or blank URLs returned by Pocket.  (Fixes [[https://github.com/alphapapa/pocket-reader.el/issues/19][#19]], [[https://github.com/alphapapa/pocket-reader.el/issues/20][#20]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
+
 *** 0.2
 
 **** Additions

--- a/pocket-reader.el
+++ b/pocket-reader.el
@@ -654,8 +654,9 @@ one.  ITEM should be a hash-table with the appropriate keys, one
 of which is chosen as configured by
 `pocket-reader-url-priorities'."
   (let ((prioritized-url (cl-loop for key in pocket-reader-url-priorities
-                                  when (ht-get item key) ; Gets the URL
-                                  return it)))
+                                  for url = (ht-get item key) ; Gets the URL
+                                  when (s-present? url)
+                                  return url)))
     (if first
         prioritized-url
       (if-let ((domain (pocket-reader--url-domain prioritized-url))


### PR DESCRIPTION
Pocket API occasionally returns an empty string or null for resolved
and amp URLs.  We simply ignore any null or empty results and fall
back to the next URL in the priorities list.

Fix #20 and fix #19.