### PR TITLE
tag-search: Use completing-read to prompt for tag

### DIFF
--- a/pocket-reader.el
+++ b/pocket-reader.el
@@ -519,7 +519,7 @@ other special keywords."
   ;; MAYBE: Maybe add support for special keywords, but that might
   ;; make it more complicated to use than it is worth, because it
   ;; would mean making every plain word an implied tag keyword.
-  (interactive (list (read-from-minibuffer "Tag: ")))
+  (interactive (list (completing-read "Tag: " (pocket-reader--all-tags))))
   (unless (= 1 (length (s-split (rx (or "," space)) tag)))
     (user-error "Only one tag may be searched for at a time."))
   (let ((query (concat ":t:" tag)))


### PR DESCRIPTION
Pretty straightforward, just wanted to have completion for tag names in `pocket-reader-tag-search`.