### PR TITLE
Update random-item key binding in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -93,7 +93,7 @@ Commands operate on the current item or marked items.  These keys can be used in
 -  =U=: Unmark all items.
 -  =o=: Show more items (using the current count limit).
 -  =l=: Limit current view to items matching string (this does not run a new search).
--  =r=: Open random item from current items.  With prefix, read a key and call command bound to it instead of using the default opening function (e.g. use =b= to open in external browser).
+-  =R=: Open random item from current items.  With prefix, read a key and call command bound to it instead of using the default opening function (e.g. use =b= to open in external browser).
 -  =ta=: Add tags.
 -  =tr=: Remove tags.
 -  =tt=: Set tags.

--- a/pocket-reader.el
+++ b/pocket-reader.el
@@ -58,7 +58,7 @@
 ;; "U" pocket-reader-unmark-all
 ;; "o" pocket-reader-more
 ;; "l" pocket-reader-limit
-;; "r" pocket-reader-random-item
+;; "R" pocket-reader-random-item
 ;; "ta" pocket-reader-add-tags
 ;; "tr" pocket-reader-remove-tags
 ;; "tt" pocket-reader-set-tags


### PR DESCRIPTION
Looks like this was missed when `r` was changed to `R`.