### PR TITLE
Fontify based on rendered column widths

### DIFF
--- a/README.org
+++ b/README.org
@@ -123,6 +123,10 @@ These special keywords can be used when searching:
 
 - Use ~current-kill~ instead of ~gui-get-selection~.  ([[https://github.com/alphapapa/pocket-reader.el/pull/44][#44]].  Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 
+**** Fixes
+
+- Fontification of columns.  ([[https://github.com/alphapapa/pocket-reader.el/issues/36][#36]], [[https://github.com/alphapapa/pocket-reader.el/pull/40][#40]].  Thanks to [[https://github.com/oantolin][Omar Antolín Camarena]] for reporting, and to [[https://github.com/bcc32][Aaron Zeng]] for fixing.)
+
 *** 0.2.1
 
 **** Fixes


### PR DESCRIPTION
When tabulated-list-mode renders a line, it considers the remaining
available space in the selected window and may reduce the width of a
column compared to the width specified in tabulated-list-format.  As a
result, fontifying or otherwise calculating offsets based on the
widths in tabulated-list-format can lead to colors bleeding over into
the next column.

Delete function pocket-reader--column-data, which returns the
"theoretical" start and end positions of each column, and instead use
the actual text properties in the buffer.

Fixes #36.