### PR TITLE
tag-search: Offer special tag _untagged_ for completion

### DIFF
--- a/README.org
+++ b/README.org
@@ -93,7 +93,7 @@ Commands operate on the current item or marked items.  These keys can be used in
 -  =ta=: Add tags.
 -  =tr=: Remove tags.
 -  =tt=: Set tags.
--  =ts=: Search for a tag.
+-  =ts=: Search for a tag, or select =_untagged_= for items with no tags.
 
 *** Searching
 
@@ -117,6 +117,9 @@ These special keywords can be used when searching:
 
 -  Use ~completing-read~ for selecting tags.  (Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 -  Command ~pocket-reader-add-link~ also checks the clipboard for a link to add.
+-  ~pocket-reader-tag-search~ (bound to ~ts~) completion now supports
+   the ~_untagged_~ pseudo-tag, which lists items that have no tags.
+   (Thanks to [[https://github.com/bcc32][Aaron Zeng]].)
 
 *** 0.2.1
 

--- a/pocket-reader.el
+++ b/pocket-reader.el
@@ -524,7 +524,7 @@ other special keywords."
   ;; MAYBE: Maybe add support for special keywords, but that might
   ;; make it more complicated to use than it is worth, because it
   ;; would mean making every plain word an implied tag keyword.
-  (interactive (list (completing-read "Tag: " (pocket-reader--all-tags))))
+  (interactive (list (completing-read "Tag: " (cons "_untagged_" (pocket-reader--all-tags)))))
   (unless (= 1 (length (s-split (rx (or "," space)) tag)))
     (user-error "Only one tag may be searched for at a time."))
   (let ((query (concat ":t:" tag)))


### PR DESCRIPTION
This special tag searches for articles that have no tags assigned.
By default, it will appear first and so be noticeable to users, and
the name alone should be sufficiently self-documenting.

Closes #38.